### PR TITLE
Feature - Update Ireland's offset because of Daylight Savings

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -34,7 +34,7 @@ bot.start((ctx) => {
 bot.command(["pablitoindublin"], (ctx) => {
   return ctx.reply(
     `⌛ Tiempo en Montevideo y Dublin ⌛\n\n🇺🇾 Montevideo: ${getTimezoneTime()}\n🇮🇪 Dublin: ${getTimezoneTime(
-      0
+      1
     )}`
   );
 });


### PR DESCRIPTION
Now Ireland is UTC+01, that's a 4 hours difference between Montevideo and Dublin.